### PR TITLE
Test Unitario de controladores

### DIFF
--- a/tests/movimientoCuentaCorrienteCofre.test.ts
+++ b/tests/movimientoCuentaCorrienteCofre.test.ts
@@ -1,0 +1,292 @@
+import { Request, Response } from 'express';
+import * as MovimientoController from '../src/controllers/movimientoCuentaCorrienteCofre.controller';
+import MovimientoService from '../src/service/movimientoCuentaCorrienteCofre.service';
+
+jest.mock('../src/configs/database', () => {
+  return {
+    authenticate: jest.fn().mockResolvedValue(true),
+    define: jest.fn(),
+    sync: jest.fn().mockResolvedValue(true),
+    __esModule: true,
+    default: {
+      authenticate: jest.fn().mockResolvedValue(true),
+      define: jest.fn(),
+      sync: jest.fn().mockResolvedValue(true),
+    }
+  };
+});
+
+jest.mock('../src/models/movimientoCuentaCorrienteCofre.models', () => {
+  return {
+    __esModule: true,
+    default: {
+      init: jest.fn(),
+      findAll: jest.fn(),
+      findOne: jest.fn(),
+      findByPk: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      destroy: jest.fn(),
+    }
+  };
+});
+
+jest.mock('../src/models/pagosCofres.models', () => {
+  return {
+    __esModule: true,
+    default: {
+      init: jest.fn(),
+      findAll: jest.fn(),
+      findOne: jest.fn(),
+      findByPk: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      destroy: jest.fn(),
+    }
+  };
+});
+
+jest.mock('../src/service/movimientoCuentaCorrienteCofre.service');
+
+describe('MovimientoCuentaCorrienteCofreController', () => {
+  let mockRequest: Partial<Request>;
+  let mockResponse: Partial<Response>;
+  let responseObject: any;
+
+  beforeEach(() => {
+    responseObject = {
+      json: jest.fn(),
+      status: jest.fn().mockReturnThis(),
+    };
+    mockRequest = {};
+    mockResponse = responseObject;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getMovimientos', () => {
+    it('debería devolver todos los movimientos exitosamente', async () => {
+      const mockMovimientos = [
+        {
+          MovimientoCuentaCorrienteCofre_id: 1,
+          MovimientoCuentaCorrienteCofre_clienteId: 1,
+          MovimientoCuentaCorrienteCofre_importe: 1000
+        },
+        {
+          MovimientoCuentaCorrienteCofre_id: 2,
+          MovimientoCuentaCorrienteCofre_clienteId: 2,
+          MovimientoCuentaCorrienteCofre_importe: 2000
+        }
+      ];
+
+      (MovimientoService.getAllMovimientos as jest.Mock).mockResolvedValue(mockMovimientos);
+
+      await MovimientoController.getMovimientos(
+        mockRequest as Request,
+        mockResponse as Response
+      );
+
+      expect(responseObject.json).toHaveBeenCalledWith(mockMovimientos);
+    });
+
+    it('debería manejar errores al obtener movimientos', async () => {
+      const mockError = new Error('Error de base de datos');
+      (MovimientoService.getAllMovimientos as jest.Mock).mockRejectedValue(mockError);
+
+      await MovimientoController.getMovimientos(
+        mockRequest as Request,
+        mockResponse as Response
+      );
+
+      expect(responseObject.status).toHaveBeenCalledWith(500);
+      expect(responseObject.json).toHaveBeenCalledWith({
+        message: 'Error al obtener movimientos',
+        error: mockError
+      });
+    });
+  });
+
+  describe('getMovimientoById', () => {
+    it('debería devolver un movimiento cuando existe', async () => {
+      const mockMovimiento = {
+        MovimientoCuentaCorrienteCofre_id: 1,
+        MovimientoCuentaCorrienteCofre_clienteId: 1,
+        MovimientoCuentaCorrienteCofre_importe: 1000
+      };
+
+      mockRequest = {
+        params: { id: '1' }
+      };
+
+      (MovimientoService.getMovimientoById as jest.Mock).mockResolvedValue(mockMovimiento);
+
+      await MovimientoController.getMovimientoById(
+        mockRequest as Request,
+        mockResponse as Response
+      );
+
+      expect(responseObject.json).toHaveBeenCalledWith(mockMovimiento);
+    });
+
+    it('debería devolver 404 cuando el movimiento no existe', async () => {
+      mockRequest = {
+        params: { id: '999' }
+      };
+
+      (MovimientoService.getMovimientoById as jest.Mock).mockResolvedValue(null);
+
+      await MovimientoController.getMovimientoById(
+        mockRequest as Request,
+        mockResponse as Response
+      );
+
+      expect(responseObject.status).toHaveBeenCalledWith(404);
+      expect(responseObject.json).toHaveBeenCalledWith({
+        message: 'Movimiento no encontrado'
+      });
+    });
+  });
+
+  describe('getMovimientosByClienteId', () => {
+    it('debería devolver movimientos cuando existen para el cliente', async () => {
+      const mockMovimientos = [
+        {
+          MovimientoCuentaCorrienteCofre_id: 1,
+          MovimientoCuentaCorrienteCofre_clienteId: 1,
+          MovimientoCuentaCorrienteCofre_importe: 1000
+        }
+      ];
+
+      mockRequest = {
+        params: { clienteId: '1' }
+      };
+
+      (MovimientoService.getMovimientosByClienteId as jest.Mock).mockResolvedValue(mockMovimientos);
+
+      await MovimientoController.getMovimientosByClienteId(
+        mockRequest as Request,
+        mockResponse as Response
+      );
+
+      expect(responseObject.json).toHaveBeenCalledWith(mockMovimientos);
+    });
+
+    it('debería devolver 404 cuando no hay movimientos para el cliente', async () => {
+      mockRequest = {
+        params: { clienteId: '999' }
+      };
+
+      (MovimientoService.getMovimientosByClienteId as jest.Mock).mockResolvedValue([]);
+
+      await MovimientoController.getMovimientosByClienteId(
+        mockRequest as Request,
+        mockResponse as Response
+      );
+
+      expect(responseObject.status).toHaveBeenCalledWith(404);
+      expect(responseObject.json).toHaveBeenCalledWith({
+        message: 'No se encontraron movimientos para este cliente'
+      });
+    });
+  });
+
+  describe('getMovimientosByFecha', () => {
+    it('debería devolver movimientos cuando existen para la fecha', async () => {
+      const mockMovimientos = [
+        {
+          MovimientoCuentaCorrienteCofre_id: 1,
+          MovimientoCuentaCorrienteCofre_fechaIngreso: new Date('2024-01-01'),
+          MovimientoCuentaCorrienteCofre_importe: 1000
+        }
+      ];
+
+      mockRequest = {
+        params: { fecha: '2024-01-01' }
+      };
+
+      (MovimientoService.getMovimientosByFecha as jest.Mock).mockResolvedValue(mockMovimientos);
+
+      await MovimientoController.getMovimientosByFecha(
+        mockRequest as Request,
+        mockResponse as Response
+      );
+
+      expect(responseObject.json).toHaveBeenCalledWith(mockMovimientos);
+    });
+
+    it('debería devolver 404 cuando no hay movimientos para la fecha', async () => {
+      mockRequest = {
+        params: { fecha: '2024-01-01' }
+      };
+
+      (MovimientoService.getMovimientosByFecha as jest.Mock).mockResolvedValue([]);
+
+      await MovimientoController.getMovimientosByFecha(
+        mockRequest as Request,
+        mockResponse as Response
+      );
+
+      expect(responseObject.status).toHaveBeenCalledWith(404);
+      expect(responseObject.json).toHaveBeenCalledWith({
+        message: 'No se encontraron movimientos para esta fecha'
+      });
+    });
+  });
+
+  describe('getMovimientoWithPagos', () => {
+    it('debería devolver movimientos y pagos cuando existen para el cliente', async () => {
+      const mockData = {
+        movimientos: [
+          {
+            MovimientoCuentaCorrienteCofre_id: 1,
+            MovimientoCuentaCorrienteCofre_clienteId: 1,
+            MovimientoCuentaCorrienteCofre_importe: 1000
+          }
+        ],
+        pagos: [
+          {
+            pagosCofres_id: 1,
+            pagosCofres_contrato: 1,
+            pagosCofres_importe: 1000
+          }
+        ]
+      };
+
+      mockRequest = {
+        params: { clienteId: '1' }
+      };
+
+      (MovimientoService.getMovimientoWithPagos as jest.Mock).mockResolvedValue(mockData);
+
+      await MovimientoController.getMovimientoWithPagos(
+        mockRequest as Request,
+        mockResponse as Response
+      );
+
+      expect(responseObject.json).toHaveBeenCalledWith(mockData);
+    });
+
+    it('debería devolver 404 cuando no hay registros para el cliente', async () => {
+      mockRequest = {
+        params: { clienteId: '999' }
+      };
+
+      (MovimientoService.getMovimientoWithPagos as jest.Mock).mockResolvedValue({
+        movimientos: [],
+        pagos: []
+      });
+
+      await MovimientoController.getMovimientoWithPagos(
+        mockRequest as Request,
+        mockResponse as Response
+      );
+
+      expect(responseObject.status).toHaveBeenCalledWith(404);
+      expect(responseObject.json).toHaveBeenCalledWith({
+        message: 'No se encontraron registros para este cliente'
+      });
+    });
+  });
+});

--- a/tests/pagosCofresController.test.ts
+++ b/tests/pagosCofresController.test.ts
@@ -1,0 +1,219 @@
+import { Request, Response } from 'express';
+import * as PagosCofresController from '../src/controllers/pagosCofres.controller';
+import PagosCofresService from '../src/service/pagosCofres.service';
+
+jest.mock('../src/configs/database', () => {
+    return {
+      authenticate: jest.fn().mockResolvedValue(true),
+      define: jest.fn(),
+      sync: jest.fn().mockResolvedValue(true),
+      __esModule: true,
+      default: {
+        authenticate: jest.fn().mockResolvedValue(true),
+        define: jest.fn(),
+        sync: jest.fn().mockResolvedValue(true),
+      }
+    };
+  });
+
+
+jest.mock('../src/models/pagosCofres.models', () => {
+    return {
+      __esModule: true,
+      default: {
+        init: jest.fn(),
+        findAll: jest.fn(),
+        findOne: jest.fn(),
+        findByPk: jest.fn(),
+        create: jest.fn(),
+        update: jest.fn(),
+        destroy: jest.fn(),
+      }
+    };
+  });
+
+jest.mock('../src/service/pagosCofres.service');
+
+describe('PagosCofresController', () => {
+  let mockRequest: Partial<Request>;
+  let mockResponse: Partial<Response>;
+  let responseObject: any;
+
+  beforeEach(() => {
+    responseObject = {
+      json: jest.fn(),
+      status: jest.fn().mockReturnThis(),
+    };
+    mockRequest = {};
+    mockResponse = responseObject;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getAllPagosCofres', () => {
+    it('debería devolver todos los pagos de cofres exitosamente', async () => {
+      const mockPagos = [
+        {
+          pagosCofres_id: 1,
+          pagosCofres_contrato: 1,
+          pagosCofres_importe: 500.00,
+          pagosCofres_periodo: 1,
+          pagosCofres_anio: 2024,
+          pagosCofres_fechaPago: new Date(),
+          pagosCofres_estado: 'PAGADO',
+          pagosCofres_facturaNumero: 'A-0001',
+          pagosCofres_bonificacion: 0.00,
+          pagosCofres_importeCuotaSocial: 0.00,
+          pagosCofres_depositoEnGarantia: 0.00
+        }
+      ];
+
+      (PagosCofresService.getAllPagosCofres as jest.Mock).mockResolvedValue(mockPagos);
+
+      await PagosCofresController.getAllPagosCofres(
+        mockRequest as Request,
+        mockResponse as Response
+      );
+
+      expect(responseObject.json).toHaveBeenCalledWith(mockPagos);
+    });
+
+    it('debería manejar errores al obtener pagos', async () => {
+      const mockError = new Error('Error de base de datos');
+      (PagosCofresService.getAllPagosCofres as jest.Mock).mockRejectedValue(mockError);
+
+      await PagosCofresController.getAllPagosCofres(
+        mockRequest as Request,
+        mockResponse as Response
+      );
+
+      expect(responseObject.status).toHaveBeenCalledWith(500);
+      expect(responseObject.json).toHaveBeenCalledWith({
+        message: 'Error al obtener pagos de cofres',
+        error: mockError
+      });
+    });
+  });
+
+  describe('getPagosCofresById', () => {
+    it('debería devolver un pago cuando existe', async () => {
+      const mockPago = {
+        pagosCofres_id: 1,
+        pagosCofres_contrato: 1,
+        pagosCofres_importe: 500.00,
+        pagosCofres_periodo: 1,
+        pagosCofres_anio: 2024,
+        pagosCofres_fechaPago: new Date(),
+        pagosCofres_estado: 'PAGADO',
+        pagosCofres_facturaNumero: 'A-0001',
+        pagosCofres_bonificacion: 0.00,
+        pagosCofres_importeCuotaSocial: 0.00,
+        pagosCofres_depositoEnGarantia: 0.00
+      };
+
+      mockRequest = {
+        params: { id: '1' }
+      };
+
+      (PagosCofresService.getPagosCofresById as jest.Mock).mockResolvedValue(mockPago);
+
+      await PagosCofresController.getPagosCofresById(
+        mockRequest as Request,
+        mockResponse as Response
+      );
+
+      expect(responseObject.json).toHaveBeenCalledWith(mockPago);
+    });
+
+    it('debería devolver 404 cuando el pago no existe', async () => {
+      mockRequest = {
+        params: { id: '999' }
+      };
+
+      (PagosCofresService.getPagosCofresById as jest.Mock).mockResolvedValue(null);
+
+      await PagosCofresController.getPagosCofresById(
+        mockRequest as Request,
+        mockResponse as Response
+      );
+
+      expect(responseObject.status).toHaveBeenCalledWith(404);
+      expect(responseObject.json).toHaveBeenCalledWith({
+        message: 'Pago de cofre no encontrado'
+      });
+    });
+  });
+
+  describe('getPagosCofresByContrato', () => {
+    it('debería devolver pagos cuando existen para el contrato', async () => {
+      const mockPagos = [
+        {
+          pagosCofres_id: 1,
+          pagosCofres_contrato: 1,
+          pagosCofres_importe: 500.00,
+          pagosCofres_periodo: 1,
+          pagosCofres_anio: 2024,
+          pagosCofres_fechaPago: new Date(),
+          pagosCofres_estado: 'PAGADO',
+          pagosCofres_facturaNumero: 'A-0001',
+          pagosCofres_bonificacion: 0.00,
+          pagosCofres_importeCuotaSocial: 0.00,
+          pagosCofres_depositoEnGarantia: 0.00
+        }
+      ];
+
+      mockRequest = {
+        params: { contratoId: '1' }
+      };
+
+      (PagosCofresService.getPagosCofresByContrato as jest.Mock).mockResolvedValue(mockPagos);
+
+      await PagosCofresController.getPagosCofresByContrato(
+        mockRequest as Request,
+        mockResponse as Response
+      );
+
+      expect(responseObject.json).toHaveBeenCalledWith(mockPagos);
+    });
+
+    it('debería devolver 404 cuando no hay pagos para el contrato', async () => {
+      mockRequest = {
+        params: { contratoId: '999' }
+      };
+
+      (PagosCofresService.getPagosCofresByContrato as jest.Mock).mockResolvedValue([]);
+
+      await PagosCofresController.getPagosCofresByContrato(
+        mockRequest as Request,
+        mockResponse as Response
+      );
+
+      expect(responseObject.status).toHaveBeenCalledWith(404);
+      expect(responseObject.json).toHaveBeenCalledWith({
+        message: 'No se encontraron pagos para este contrato'
+      });
+    });
+
+    it('debería manejar errores al obtener pagos por contrato', async () => {
+      mockRequest = {
+        params: { contratoId: '1' }
+      };
+
+      const mockError = new Error('Error de base de datos');
+      (PagosCofresService.getPagosCofresByContrato as jest.Mock).mockRejectedValue(mockError);
+
+      await PagosCofresController.getPagosCofresByContrato(
+        mockRequest as Request,
+        mockResponse as Response
+      );
+
+      expect(responseObject.status).toHaveBeenCalledWith(500);
+      expect(responseObject.json).toHaveBeenCalledWith({
+        message: 'Error al obtener los pagos del contrato',
+        error: mockError
+      });
+    });
+  });
+});

--- a/tests/pagosSociosController.test.ts
+++ b/tests/pagosSociosController.test.ts
@@ -1,0 +1,223 @@
+import { Request, Response } from 'express';
+import * as PagosSociosController from '../src/controllers/pagosSocios.controller';
+import PagosSociosService from '../src/service/pagosSocios.service';
+
+jest.mock('../src/configs/database', () => {
+  return {
+    authenticate: jest.fn().mockResolvedValue(true),
+    define: jest.fn(),
+    sync: jest.fn().mockResolvedValue(true),
+    __esModule: true,
+    default: {
+      authenticate: jest.fn().mockResolvedValue(true),
+      define: jest.fn(),
+      sync: jest.fn().mockResolvedValue(true),
+    }
+  };
+});
+
+jest.mock('../src/models/pagosSocios.models', () => {
+  return {
+    __esModule: true,
+    default: {
+      init: jest.fn(),
+      findAll: jest.fn(),
+      findOne: jest.fn(),
+      findByPk: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      destroy: jest.fn(),
+    }
+  };
+});
+
+jest.mock('../src/service/pagosSocios.service');
+
+describe('PagosSociosController', () => {
+  let mockRequest: Partial<Request>;
+  let mockResponse: Partial<Response>;
+  let responseObject: any;
+
+  beforeEach(() => {
+    responseObject = {
+      json: jest.fn(),
+      status: jest.fn().mockReturnThis(),
+    };
+    mockRequest = {};
+    mockResponse = responseObject;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getAllPagosSocios', () => {
+    it('debería devolver todos los pagos de socios exitosamente', async () => {
+      const mockPagosSocios = [
+        {
+          pagosSocios_id: 1,
+          pagosSocios_socio: 1,
+          pagosSocios_monto: 1000,
+          pagosSocios_estado: 'PAGADO'
+        },
+        {
+          pagosSocios_id: 2,
+          pagosSocios_socio: 2,
+          pagosSocios_monto: 2000,
+          pagosSocios_estado: 'PENDIENTE'
+        }
+      ];
+
+      (PagosSociosService.getAllPagosSocios as jest.Mock).mockResolvedValue(mockPagosSocios);
+
+      await PagosSociosController.getAllPagosSocios(
+        mockRequest as Request,
+        mockResponse as Response
+      );
+
+      expect(responseObject.json).toHaveBeenCalledWith(mockPagosSocios);
+    });
+
+    it('debería manejar errores al obtener pagos de socios', async () => {
+      const mockError = new Error('Error de base de datos');
+      (PagosSociosService.getAllPagosSocios as jest.Mock).mockRejectedValue(mockError);
+
+      await PagosSociosController.getAllPagosSocios(
+        mockRequest as Request,
+        mockResponse as Response
+      );
+
+      expect(responseObject.status).toHaveBeenCalledWith(500);
+      expect(responseObject.json).toHaveBeenCalledWith({
+        message: 'Error al obtener pagos de socios',
+        error: mockError
+      });
+    });
+  });
+
+  describe('getPagosSociosById', () => {
+    it('debería devolver un pago de socio cuando existe', async () => {
+      const mockPagoSocio = {
+        pagosSocios_id: 1,
+        pagosSocios_socio: 1,
+        pagosSocios_monto: 1000,
+        pagosSocios_estado: 'PAGADO'
+      };
+
+      mockRequest = {
+        params: { id: '1' }
+      };
+
+      (PagosSociosService.getPagosSociosById as jest.Mock).mockResolvedValue(mockPagoSocio);
+
+      await PagosSociosController.getPagosSociosById(
+        mockRequest as Request,
+        mockResponse as Response
+      );
+
+      expect(responseObject.json).toHaveBeenCalledWith(mockPagoSocio);
+    });
+
+    it('debería devolver 404 cuando el pago de socio no existe', async () => {
+      mockRequest = {
+        params: { id: '999' }
+      };
+
+      (PagosSociosService.getPagosSociosById as jest.Mock).mockResolvedValue(null);
+
+      await PagosSociosController.getPagosSociosById(
+        mockRequest as Request,
+        mockResponse as Response
+      );
+
+      expect(responseObject.status).toHaveBeenCalledWith(404);
+      expect(responseObject.json).toHaveBeenCalledWith({
+        message: 'Pago de socio no encontrado'
+      });
+    });
+
+    it('debería manejar errores al obtener pago de socio por ID', async () => {
+      mockRequest = {
+        params: { id: '1' }
+      };
+
+      const mockError = new Error('Error de base de datos');
+      (PagosSociosService.getPagosSociosById as jest.Mock).mockRejectedValue(mockError);
+
+      await PagosSociosController.getPagosSociosById(
+        mockRequest as Request,
+        mockResponse as Response
+      );
+
+      expect(responseObject.status).toHaveBeenCalledWith(500);
+      expect(responseObject.json).toHaveBeenCalledWith({
+        message: 'Error al obtener el pago de socio',
+        error: mockError
+      });
+    });
+  });
+
+  describe('getPagosSociosBySocio', () => {
+    it('debería devolver pagos cuando existen para el socio', async () => {
+      const mockPagosSocios = [
+        {
+          pagosSocios_id: 1,
+          pagosSocios_socio: 1,
+          pagosSocios_monto: 1000,
+          pagosSocios_estado: 'PAGADO'
+        }
+      ];
+
+      mockRequest = {
+        params: { socioId: '1' }
+      };
+
+      (PagosSociosService.getPagosSociosBySocio as jest.Mock).mockResolvedValue(mockPagosSocios);
+
+      await PagosSociosController.getPagosSociosBySocio(
+        mockRequest as Request,
+        mockResponse as Response
+      );
+
+      expect(responseObject.json).toHaveBeenCalledWith(mockPagosSocios);
+    });
+
+    it('debería devolver 404 cuando no hay pagos para el socio', async () => {
+      mockRequest = {
+        params: { socioId: '999' }
+      };
+
+      (PagosSociosService.getPagosSociosBySocio as jest.Mock).mockResolvedValue([]);
+
+      await PagosSociosController.getPagosSociosBySocio(
+        mockRequest as Request,
+        mockResponse as Response
+      );
+
+      expect(responseObject.status).toHaveBeenCalledWith(404);
+      expect(responseObject.json).toHaveBeenCalledWith({
+        message: 'No se encontraron pagos para este socio'
+      });
+    });
+
+    it('debería manejar errores al obtener pagos por socio', async () => {
+      mockRequest = {
+        params: { socioId: '1' }
+      };
+
+      const mockError = new Error('Error de base de datos');
+      (PagosSociosService.getPagosSociosBySocio as jest.Mock).mockRejectedValue(mockError);
+
+      await PagosSociosController.getPagosSociosBySocio(
+        mockRequest as Request,
+        mockResponse as Response
+      );
+
+      expect(responseObject.status).toHaveBeenCalledWith(500);
+      expect(responseObject.json).toHaveBeenCalledWith({
+        message: 'Error al obtener los pagos del socio',
+        error: mockError
+      });
+    });
+  });
+});

--- a/tests/socioController.test.ts
+++ b/tests/socioController.test.ts
@@ -1,0 +1,232 @@
+import { Request, Response } from 'express';
+import * as SocioController from '../src/controllers/socio.controller';
+import SocioService from '../src/service/socio.service';
+
+// Mock de la base de datos
+jest.mock('../src/configs/database', () => {
+  return {
+    authenticate: jest.fn().mockResolvedValue(true),
+    define: jest.fn(),
+    sync: jest.fn().mockResolvedValue(true),
+    __esModule: true,
+    default: {
+      authenticate: jest.fn().mockResolvedValue(true),
+      define: jest.fn(),
+      sync: jest.fn().mockResolvedValue(true),
+    }
+  };
+});
+
+// Mock del modelo Socio
+jest.mock('../src/models/socio.models', () => {
+  return {
+    __esModule: true,
+    default: {
+      init: jest.fn(),
+      findAll: jest.fn(),
+      findOne: jest.fn(),
+      findByPk: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      destroy: jest.fn(),
+    }
+  };
+});
+
+// Mock del modelo PagosSocios
+jest.mock('../src/models/pagosSocios.models', () => {
+  return {
+    __esModule: true,
+    default: {
+      init: jest.fn(),
+      findAll: jest.fn(),
+      findOne: jest.fn(),
+      findByPk: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      destroy: jest.fn(),
+      belongsTo: jest.fn(),
+      hasMany: jest.fn(),
+    }
+  };
+});
+
+// Mock del servicio
+jest.mock('../src/service/socio.service');
+
+describe('SocioController', () => {
+  let mockRequest: Partial<Request>;
+  let mockResponse: Partial<Response>;
+  let responseObject: any;
+
+  beforeEach(() => {
+    responseObject = {
+      json: jest.fn(),
+      status: jest.fn().mockReturnThis(),
+    };
+    mockRequest = {};
+    mockResponse = responseObject;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getSocios', () => {
+    it('debería devolver todos los socios exitosamente', async () => {
+      const mockSocios = [
+        { socio_id: 1, socio_nombre: 'Juan', socio_apellido: 'Pérez' },
+        { socio_id: 2, socio_nombre: 'María', socio_apellido: 'González' }
+      ];
+
+      (SocioService.getAllSocios as jest.Mock).mockResolvedValue(mockSocios);
+
+      await SocioController.getSocios(
+        mockRequest as Request,
+        mockResponse as Response
+      );
+
+      expect(responseObject.json).toHaveBeenCalledWith(mockSocios);
+    });
+
+    it('debería manejar errores al obtener socios', async () => {
+      const mockError = new Error('Error de base de datos');
+      (SocioService.getAllSocios as jest.Mock).mockRejectedValue(mockError);
+
+      await SocioController.getSocios(
+        mockRequest as Request,
+        mockResponse as Response
+      );
+
+      expect(responseObject.status).toHaveBeenCalledWith(500);
+      expect(responseObject.json).toHaveBeenCalledWith({
+        message: 'Error al obtener socios',
+        error: mockError
+      });
+    });
+  });
+
+  describe('getSocioById', () => {
+    it('debería devolver un socio cuando existe', async () => {
+      const mockSocio = {
+        socio_id: 1,
+        socio_nombre: 'Juan',
+        socio_apellido: 'Pérez'
+      };
+
+      mockRequest = {
+        params: { id: '1' }
+      };
+
+      (SocioService.getSocioById as jest.Mock).mockResolvedValue(mockSocio);
+
+      await SocioController.getSocioById(
+        mockRequest as Request,
+        mockResponse as Response
+      );
+
+      expect(responseObject.json).toHaveBeenCalledWith(mockSocio);
+    });
+
+    it('debería devolver 404 cuando el socio no existe', async () => {
+      mockRequest = {
+        params: { id: '999' }
+      };
+
+      (SocioService.getSocioById as jest.Mock).mockResolvedValue(null);
+
+      await SocioController.getSocioById(
+        mockRequest as Request,
+        mockResponse as Response
+      );
+
+      expect(responseObject.status).toHaveBeenCalledWith(404);
+      expect(responseObject.json).toHaveBeenCalledWith({
+        message: 'Socio no encontrado'
+      });
+    });
+  });
+
+  describe('getSociosByEmail', () => {
+    it('debería devolver socios cuando existen para el email', async () => {
+      const mockSocios = [
+        { socio_id: 1, socio_nombre: 'Juan', socio_mail: 'juan@test.com' }
+      ];
+
+      mockRequest = {
+        params: { email: 'juan@test.com' }
+      };
+
+      (SocioService.getSociosByEmail as jest.Mock).mockResolvedValue(mockSocios);
+
+      await SocioController.getSociosByEmail(
+        mockRequest as Request,
+        mockResponse as Response
+      );
+
+      expect(responseObject.json).toHaveBeenCalledWith(mockSocios);
+    });
+
+    it('debería devolver 404 cuando no hay socios para el email', async () => {
+      mockRequest = {
+        params: { email: 'noexiste@test.com' }
+      };
+
+      (SocioService.getSociosByEmail as jest.Mock).mockResolvedValue([]);
+
+      await SocioController.getSociosByEmail(
+        mockRequest as Request,
+        mockResponse as Response
+      );
+
+      expect(responseObject.status).toHaveBeenCalledWith(404);
+      expect(responseObject.json).toHaveBeenCalledWith({
+        message: 'No se encontraron socios para este correo'
+      });
+    });
+  });
+
+  describe('getSocioWithPagos', () => {
+    it('debería devolver un socio con sus pagos cuando existe', async () => {
+      const mockSocioWithPagos = {
+        socio_id: 1,
+        socio_nombre: 'Juan',
+        pagos: [
+          { id: 1, monto: 1000 },
+          { id: 2, monto: 2000 }
+        ]
+      };
+
+      mockRequest = {
+        params: { id: '1' }
+      };
+
+      (SocioService.getSocioWithPagos as jest.Mock).mockResolvedValue(mockSocioWithPagos);
+
+      await SocioController.getSocioWithPagos(
+        mockRequest as Request,
+        mockResponse as Response
+      );
+
+      expect(responseObject.json).toHaveBeenCalledWith(mockSocioWithPagos);
+    });
+
+    it('debería devolver 404 cuando el socio no existe', async () => {
+      mockRequest = {
+        params: { id: '999' }
+      };
+
+      (SocioService.getSocioWithPagos as jest.Mock).mockResolvedValue(null);
+
+      await SocioController.getSocioWithPagos(
+        mockRequest as Request,
+        mockResponse as Response
+      );
+
+      expect(responseObject.status).toHaveBeenCalledWith(404);
+      expect(responseObject.json).toHaveBeenCalledWith({
+        message: 'Socio no encontrado'
+      });
+    });
+  });
+});


### PR DESCRIPTION
### Test unitarios para SocioController

**getSocios**

- Verifica que todos los socios se devuelvan correctamente.
- Maneja y prueba errores de base de datos al obtener socios.

**getSocioById**

- Verifica la devolución de un socio específico cuando existe.
- Maneja el caso cuando el socio no existe (retorna 404).

**getSociosByEmail**

- Verifica que los socios asociados a un correo electrónico se devuelvan correctamente.
- Maneja el caso cuando no existen socios con ese correo (retorna 404).

### Test unitarios para PagosSociosController

**getAllPagosSocios**

- Verifica que los pagos de socios se devuelvan correctamente.
- Maneja y prueba la respuesta en caso de errores de base de datos.

**getPagosSociosById**

- Verifica la devolución de un pago específico cuando existe.
- Maneja el caso cuando el pago no existe (retorna 404).
- Maneja y prueba errores de base de datos al buscar pagos por ID.

**getPagosSociosBySocio**

- Verifica la devolución de pagos asociados a un socio específico.
- Maneja el caso cuando no hay pagos para el socio (retorna 404).
- Maneja y prueba errores de base de datos al buscar pagos por socio.

### Test unitarios para MovimientoCuentaCorrienteCofre

**getMovimientos**

- Verifica que se devuelven correctamente los movimientos obtenidos desde el servicio.
- Comprueba que, en caso de error, el servidor responde con el código de estado 500.

**getMovimientoById**

- Verifica que un movimiento se devuelve correctamente cuando existe.
- Comprueba que, en caso de que no se encuentre un movimiento, el servidor devuelve un 404.

**getMovimientosByClienteId**

- Verifica que se devuelven los movimientos cuando existen para un cliente.
- Si no se encuentran movimientos para el cliente, devuelve un 404.

**getMovimientosByFecha**

- Verifica que se devuelven movimientos asociados a una fecha.
- En caso de no encontrarse movimientos para esa fecha, devuelve un 404.

**getMovimientoWithPagos**

- **Verifica que se devuelven los movimientos y los pagos relacionados cuando existen para un cliente.
- En caso de no encontrar movimientos ni pagos, devuelve un 404.**

### Test unitarios para PagosCofresController

**getAllPagosCofres**

- Verifica que se devuelven correctamente todos los pagos de cofres.
- Maneja los errores correctamente, devolviendo un código de estado 500 si hay problemas con la base de datos.

**getPagosCofresById**

- Verifica que se devuelve el pago cuando existe.
- Puedes continuar implementando este test siguiendo la misma lógica que en otros controladores para manejar el caso de no encontrar un pago.